### PR TITLE
Feedback profile to cmd

### DIFF
--- a/lib/ccp/receivers/profileable.rb
+++ b/lib/ccp/receivers/profileable.rb
@@ -22,7 +22,10 @@ module Ccp
         when Ccp::Commands::Composite
           # no profiles
         else
-          profiles << Profile.new(cmd, "execute", (Time.new - start).to_f)
+          profile = Profile.new(cmd, "execute", (Time.new - start).to_f)
+          profiles << profile
+
+          cmd.on_profiled(profile) if cmd.respond_to?(:on_profiled)
         end
       end
 


### PR DESCRIPTION
## 概要
Profile 結果を cmd が即座に受け取れる仕組みが欲しいです。
プログラム終了を待たずに Profile を検証することができれば、プログラムのその後の手続きに柔軟性を与えることができます。