### PR TITLE
table 個別の close を実装する

### DIFF
--- a/lib/ccp/storage.rb
+++ b/lib/ccp/storage.rb
@@ -43,6 +43,16 @@ module Ccp
       )
     end
 
+    def close_table(name)
+      t = @tables[name.to_s]
+      if t && t.close
+        @tables.delete(name.to_s)
+        true
+      else
+        false
+      end
+    end
+
     def close
       @tables.each_pair do |_,kvs|
         kvs.close

--- a/lib/ccp/version.rb
+++ b/lib/ccp/version.rb
@@ -1,3 +1,3 @@
 module Ccp
-  VERSION = "0.4.9"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
TokyoCabinet は、明示的にロック無しによる open をしない限り、プロセスによってロックされる。ccp を利用するプロセスから立ち上げた子プロセスが、tch ファイルにアクセスしようとするとロック待ちになってアクセスできない。文脈的に Ccp::Storage.close を呼びたく無い状況下で子プロセスからのファイルアクセスを可能にするため、テーブル個別の明示的 close が欲しいです。