### PR TITLE
remove Gemfile.jruby symlink

### DIFF
--- a/Gemfile.jruby
+++ b/Gemfile.jruby
@@ -1,1 +1,3 @@
-Gemfile
+source "http://rubygems.org"
+
+gemspec


### PR DESCRIPTION
# 概要
Gemfile.jruby を symlinkではなくファイルの実体を配置するよう変更したい。

bundlerのバージョンによってはrubyのインストール箇所の参照にsymlinkが含まれている場合に、
gemにsymlinkが含まれていると正常にbundle installが完了しないためです。